### PR TITLE
Ajusta useEffect para carregar livros iniciais apenas quando não…

### DIFF
--- a/frontend/src/pages/Library.tsx
+++ b/frontend/src/pages/Library.tsx
@@ -61,10 +61,12 @@ export default function BookSearch() {
     );
 
     useEffect(() => {
-        const INITIAL_QUERY = "A";
-        setSearchTerm(INITIAL_QUERY);
-        searchBooks(0, INITIAL_QUERY);
-    }, [searchBooks]);
+        if (!searchTerm) {
+            const INITIAL_QUERY = "A";
+            setSearchTerm(INITIAL_QUERY);
+            searchBooks(0, INITIAL_QUERY);
+        }
+    }, [searchBooks, searchTerm]);
 
     const handleSearch = () => {
         if (!query.trim()) return;


### PR DESCRIPTION
## 📌 Description

Este PR corrige o comportamento da busca de livros. Agora o `useEffect` carrega a busca inicial apenas quando não existe termo definido, evitando que os resultados da pesquisa do usuário sejam sobrescritos pela busca padrão.

## 🔍 Related Issues

N/A

## ✨ Changes Made

* Ajustado o `useEffect` para verificar se `searchTerm` está vazio antes de executar a busca inicial.
* Evitado o problema de sobrescrever os resultados da pesquisa com a query padrão `"A"`.

## ✅ Checklist

* [x] O código segue os padrões e diretrizes do projeto
* [x] Testado localmente e funcionando como esperado
* [x] Nenhum novo warning ou erro no console
* [x] A UI e funcionalidade estão responsivas em diferentes tamanhos de tela
* [ ] Documentação atualizada (se necessário)

## 🚀 Additional Notes

Essa alteração garante que a experiência de busca do usuário seja consistente, sem resetar os resultados após uma pesquisa manual
