### PR TITLE
Melhora visual do menu skeleton

### DIFF
--- a/frontend/src/components/NavBar/Header.tsx
+++ b/frontend/src/components/NavBar/Header.tsx
@@ -87,12 +87,12 @@ export default function Header() {
         };
     }, []);
 
-    // 🔥 SE ESTÁ CARREGANDO → MOSTRA SKELETON
     if (isLoading) {
         return (
             <header className="fixed top-0 w-full z-50 backdrop-blur-md bg-slate-900/80 shadow-lg shadow-black/30">
                 <div className="container max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <div className="flex items-center justify-between py-4 gap-8">
+
                         <div className="h-8 w-40 bg-gray-700 rounded animate-pulse" />
 
                         <div className="md:hidden h-10 w-10 bg-gray-700 rounded-full animate-pulse" />
@@ -107,12 +107,7 @@ export default function Header() {
                             <div className="h-8 w-32 bg-gray-700 rounded animate-pulse" />
                             <div className="h-8 w-20 bg-gray-600 rounded animate-pulse" />
                         </div>
-                    </div>
 
-                    <div className="md:hidden mt-2 space-y-2">
-                        <div className="h-6 w-full bg-gray-700 rounded animate-pulse" />
-                        <div className="h-6 w-full bg-gray-700 rounded animate-pulse" />
-                        <div className="h-6 w-full bg-gray-700 rounded animate-pulse" />
                     </div>
                 </div>
             </header>


### PR DESCRIPTION
## 📌 Description

Este PR corrige o tamanho excessivo do skeleton do header em dispositivos mobile durante o estado de carregamento.
O skeleton do menu mobile estava sendo renderizado mesmo quando o menu não estava aberto, o que fazia com que o header ficasse mais alto do que o layout real.

## 🔍 Related Issues

N/A

## ✨ Changes Made

* Removido o skeleton do menu mobile no estado de carregamento
* Ajustado o layout do skeleton para refletir apenas os elementos visíveis do header
* Melhorada a consistência visual do header em telas mobile

## ✅ Checklist

* [x] Meu código segue os padrões e diretrizes do projeto
* [x] Testei as mudanças localmente para garantir que funcionam como esperado
* [x] Não há novos erros ou warnings no console
* [x] A interface e funcionalidades continuam responsivas em diferentes tamanhos de tela
* [ ] Atualizei a documentação (se necessário)

## 🚀 Additional Notes

Essa alteração melhora a experiência de carregamento no mobile e evita mudanças bruscas de layout (layout shift) durante o carregamento do header.